### PR TITLE
update backup directory volume paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ services:
     networks:
       - internal
     volumes:
-      - ./hooks:/hooks
-      - ./backup:/backup
+      - ./hooks:/cronitab/hooks
+      - ./backup:/cronitab/backup
     environment:
       MARIADB_DB: ejemplo
       MARIADB_HOST: mariadb
@@ -78,7 +78,7 @@ networks:
 
 | env variable | description |
 |--|--|
-| BACKUP_DIR | Directory to save the backup at. Defaults to `/backup`. |
+| BACKUP_DIR | Directory to save the backup at. Defaults to `/cronitab/backup`. |
 | BACKUP_SUFFIX | Filename suffix to save the backup. Defaults to `.sql.gz`. |
 | BACKUP_KEEP_DAYS | Number of daily backups to keep before removal. Defaults to `7`. |
 | BACKUP_KEEP_WEEKS | Number of weekly backups to keep before removal. Defaults to `4`. |


### PR DESCRIPTION
The compose config works only if the volume mount internal path is prepended `/cronitab`, probably because it is set so [here](https://github.com/atareao/mariadb-backup/blob/500e1fc660539236c4b3057f284b8d9cc9084a2e/backup.sh#L5).

The script could also default to `BACKUP_DIR=${BACKUP_DIR:-/backup}`, if that is preferred.
